### PR TITLE
Increase the Player Movement Speed

### DIFF
--- a/game/core/src/me/lihq/game/Settings.java
+++ b/game/core/src/me/lihq/game/Settings.java
@@ -21,7 +21,7 @@ public class Settings
     /**
      * The maximum amount of ticks per second
      */
-    public static final int TPS = 30;
+    public static final int TPS = 60;
 
     /**
      * This is whether to draw some debug features to the screen

--- a/game/core/src/me/lihq/game/people/Player.java
+++ b/game/core/src/me/lihq/game/people/Player.java
@@ -3,6 +3,7 @@ package me.lihq.game.people;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.utils.JsonReader;
 import me.lihq.game.GameMain;
+import me.lihq.game.Settings;
 import me.lihq.game.models.Clue;
 import me.lihq.game.models.Room;
 import me.lihq.game.screen.elements.SpeechBox;
@@ -42,6 +43,7 @@ public class Player extends AbstractPerson
     {
         super(name, "people/player/" + imgSrc, tileX, tileY);
         importDialogue("Player.JSON");
+        animTime = Settings.TPS / 7f;
     }
 
     /**


### PR DESCRIPTION
This will increase the player's movement speed by reducing the time the player object has to perform its move animation.

Also included in this pull request is increase the TPS (ticks per second) to 60. This is done because the representation and internal game state are intertwined. This is evident when the player changing position is depended on the animation, of which is updated in the update loop. The player position should have been exclusively the responsibility of the update loop, and the animation the render loop.

This closes #11.