### PR TITLE
Correct the javadoc docs so it will compile

### DIFF
--- a/game/core/src/me/lihq/game/GameMain.java
+++ b/game/core/src/me/lihq/game/GameMain.java
@@ -277,8 +277,8 @@ public class GameMain extends Game
     /**
      * This method returns a list of the NPCs that are in the specified room
      *
-     * @param room - The room to check
-     * @return (List<NPC>) The NPCs that are in the specified room
+     * @param room The room to check.
+     * @return The NPCs that are in the specified room.
      */
     public List<NPC> getNPCS(Room room)
     {

--- a/game/core/src/me/lihq/game/models/Map.java
+++ b/game/core/src/me/lihq/game/models/Map.java
@@ -135,9 +135,9 @@ public class Map
 
 
     /**
-     * Gets the rooms in the map
+     * Gets the rooms in the map.
      *
-     * @return (List<Room>) List of rooms that the map initialised
+     * @return List of rooms in the map.
      */
     public List<Room> getRooms()
     {

--- a/game/core/src/me/lihq/game/models/Room.java
+++ b/game/core/src/me/lihq/game/models/Room.java
@@ -394,9 +394,10 @@ public class Room
     }
 
     /**
-     * This will check the map for any potential hiding locations, and returns them as a list of coordinates
+     * This will check the map for any potential hiding locations, and returns them as a list of
+     * coordinates.
      *
-     * @return (List<Vector2Int>) list of coordinates of the hideable tiles
+     * @return List of coordinates of the possible tiles.
      */
     public List<Vector2Int> getHidingSpots()
     {

--- a/game/core/src/me/lihq/game/people/AbstractPerson.java
+++ b/game/core/src/me/lihq/game/people/AbstractPerson.java
@@ -376,10 +376,12 @@ public abstract class AbstractPerson extends Sprite
 
     /**
      * This is used to describe the direction the person is currently facing or moving in.
+     * <ul>
      * <li>{@link #NORTH}</li>
      * <li>{@link #SOUTH}</li>
      * <li>{@link #EAST}</li>
      * <li>{@link #WEST}</li>
+     * </ul>
      */
     public enum Direction
     {
@@ -453,8 +455,10 @@ public abstract class AbstractPerson extends Sprite
 
     /**
      * The state of the person explains what they are currently doing.
+     * <ul>
      * <li>{@link #WALKING}</li>
      * <li>{@link #STANDING}</li>
+     * </ul>
      */
     public enum PersonState
     {
@@ -487,13 +491,6 @@ public abstract class AbstractPerson extends Sprite
      */
     public static class PersonPositionComparator implements Comparator<AbstractPerson>
     {
-        /**
-         * This method compares the 2 objects.
-         *
-         * @param o1 - The first object to compare
-         * @param o2 - The second object to compare
-         * @return (int) if <0 o1 is considered to be first in the list
-         */
         @Override
         public int compare(AbstractPerson o1, AbstractPerson o2)
         {

--- a/game/core/src/me/lihq/game/screen/NavigationScreen.java
+++ b/game/core/src/me/lihq/game/screen/NavigationScreen.java
@@ -383,7 +383,7 @@ public class NavigationScreen extends AbstractScreen
     /**
      * This method gets the list of current NPCs in the current room
      *
-     * @return (List<NPC>) the value of currentNPCs {@link #currentNPCS}
+     * @return The list of NPCs in this room.
      */
     public List<NPC> getNPCs()
     {

--- a/game/core/src/me/lihq/game/screen/elements/SpeechBoxButton.java
+++ b/game/core/src/me/lihq/game/screen/elements/SpeechBoxButton.java
@@ -35,17 +35,20 @@ public class SpeechBoxButton
     }
 
     /**
-     * Event handler interface
-     * Used for defining the click event handler on a SpeechBoxButton
+     * An interface for use when adding a click event handler to the button.
      * <p>
      * Initialising an event handler:
-     * SpeechBoxButton.EventHandler eventHandler = (String name) -> {
-     * System.out.println(name + " was pressed");
-     * };
+     * </p>
+     * <pre>
+     * SpeechBoxButton.EventHandler eventHandler = (String name) -&gt; {
+     *     System.out.println(name + " was pressed");
+     * };</pre>
      * <p>
      * Usage:
      * Used in SpeechBox class on button click
-     * SpeechBoxButton.eventHandler.trigger();
+     * </p>
+     * <pre>
+     * SpeechBoxButton.eventHandler.trigger();</pre>
      */
     public interface EventHandler
     {


### PR DESCRIPTION
This closes #24.

Side rant: Why is the return type included with the `@return` tags? They're already in the method signature, no more than a few lines away.

There's still plenty of warnings about the javadoc to correct, but this'll do for now.